### PR TITLE
Remove %24 from backup duration

### DIFF
--- a/root/sbin/e-smith/backup-data
+++ b/root/sbin/e-smith/backup-data
@@ -111,7 +111,7 @@ if (!$backup->is_running('backup-data')) {
 out("Backup status: SUCCESS");
 out("Backup ended at %s", strftime('%F %T',localtime));
 my $duration = time - $start;
-out("Time elapsed: %s hours, %s minutes, %s seconds", ($duration/(60*60))%24, ($duration/60)%60, $duration%60);
+out("Time elapsed: %s hours, %s minutes, %s seconds", ($duration/(60*60)), ($duration/60)%60, $duration%60);
 
 if ($name eq '') {
     # disk usage stats


### PR DESCRIPTION
Remove modulo 24 from backup duration, so reported duration will be correct when exceeding 24 hours.